### PR TITLE
adding to install other things as it give some error, install python-…

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -66,6 +66,7 @@ kolla-ansible -i ./all-in-one deploy
 pip install python-openstackclient -c https://releases.openstack.org/constraints/upper/master --ignore-installed
 kolla-ansible post-deploy
 . /etc/kolla/admin-openrc.sh
+pip3 install python-openstackclient
 /usr/local/share/kolla-ansible/init-runonce
 
 # changing virt_type in nova-com 


### PR DESCRIPTION
…openstackclient when we run afterward cmd

As in some *system* when we run the cmd ***/usr/local/share/kolla-ansible/init-runonce*** some error is come and said to install python-openstackclient and we think we have already installed it through ***pip install python-openstackclient -c https://releases.openstack.org/constraints/upper/master***  but for the user to run the script it will skip this and deployment is not done sucessfully. So making our script to run anywhere we have added the separate cmd.